### PR TITLE
:recycle: Passage de l'autoloader en PSR-0

### DIFF
--- a/src/Esendex/Http/HttpClient.php
+++ b/src/Esendex/Http/HttpClient.php
@@ -127,7 +127,7 @@ class HttpClient implements IHttp
             if (strlen($data) == 0) {
                 $httpHeaders[] = 'Content-Length: 0';
             }
-            $httpHeaders[] = "Content-Type: ${contentType}; charset=utf-8";
+            $httpHeaders[] = "Content-Type: {$contentType}; charset=utf-8";
         }
         \curl_setopt($curlHandle, CURLOPT_HTTPHEADER, $httpHeaders);
 

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -36,7 +36,7 @@ namespace Esendex;
 
 define('ESENDEX_HOME', dirname(__FILE__));
 
-class AutoLoader
+class AutoLoad
 {
     const SPLIT_DIR = DIRECTORY_SEPARATOR;
     const SPLIT_NS = '\\';
@@ -55,4 +55,4 @@ class AutoLoader
     }
 }
 
-\spl_autoload_register(array('\Esendex\AutoLoader', 'load'));
+\spl_autoload_register(array('\Esendex\AutoLoad', 'load'));


### PR DESCRIPTION
🏷️ **Carte trello** : [carte 189](https://trello.com/c/6dXbaFLt)

❓ **Description** : Passage de l'autoloader en PSR-0 car pas psr0 compliant pour composer et php 8.2.